### PR TITLE
Fix Doxygen parameter warnings

### DIFF
--- a/include/kurlyk/http/HttpRequestManager/HttpBatchRequestHandler.hpp
+++ b/include/kurlyk/http/HttpRequestManager/HttpBatchRequestHandler.hpp
@@ -13,7 +13,7 @@ namespace kurlyk {
     public:
 
         /// \brief Constructs a handler for managing multiple HTTP requests asynchronously.
-        /// \param request_list List of unique pointers to HttpRequestContext objects.
+        /// \param context_list List of unique pointers to HttpRequestContext objects.
         explicit HttpBatchRequestHandler(std::vector<std::unique_ptr<HttpRequestContext>>& context_list)
             : m_multi_handle(curl_multi_init()) {
             for (auto& context : context_list) {

--- a/include/kurlyk/utils/url_utils.hpp
+++ b/include/kurlyk/utils/url_utils.hpp
@@ -121,7 +121,7 @@ namespace kurlyk::utils {
 
     /// \brief Validates if a URL is correctly formatted.
     /// \param url The URL string to validate.
-    /// \param protocols A vector of valid protocol schemes.
+    /// \param protocol A vector of valid protocol schemes.
     /// \return True if the URL is valid, otherwise false.
     bool is_valid_url(const std::string& url, const std::vector<std::string>& protocol) {
         size_t scheme_end = url.find("://");

--- a/include/kurlyk/websocket/WebSocketClient.hpp
+++ b/include/kurlyk/websocket/WebSocketClient.hpp
@@ -23,6 +23,7 @@ namespace kurlyk {
 
         /// \brief Constructor with configuration.
         /// \param config A unique pointer to a WebSocketConfig object.
+        /// \param callback Callback invoked when configuration is completed.
         WebSocketClient(std::unique_ptr<WebSocketConfig> config, std::function<void(bool)> callback = nullptr) {
             ensure_initialized();
             m_client = WebSocketManager::get_instance().create_client();

--- a/include/kurlyk/websocket/client/BaseWebSocketClient.hpp
+++ b/include/kurlyk/websocket/client/BaseWebSocketClient.hpp
@@ -185,12 +185,12 @@ namespace kurlyk {
         virtual void deinit_websocket() = 0;
 
         /// \brief Sends a WebSocket message.
-        /// \param message Reference to WebSocketSendInfo containing message details.
-        virtual void send_message(std::shared_ptr<WebSocketSendInfo>&) = 0;
+        /// \param send_info Reference to WebSocketSendInfo containing message details.
+        virtual void send_message(std::shared_ptr<WebSocketSendInfo>& send_info) = 0;
 
         /// \brief Sends a close request.
-        /// \param message Reference to WebSocketSendInfo containing close details.
-        virtual void send_close(std::shared_ptr<WebSocketSendInfo>&) = 0;
+        /// \param send_info Reference to WebSocketSendInfo containing close details.
+        virtual void send_close(std::shared_ptr<WebSocketSendInfo>& send_info) = 0;
 
         /// \brief Creates a generic WebSocket event.
         /// \return Unique pointer to the created WebSocketEventData.


### PR DESCRIPTION
## Summary
- sync Doxygen comments with function signatures

## Testing
- `doxygen -q`

------
https://chatgpt.com/codex/tasks/task_e_688be4732664832ca82ec860ec536bb0