### PR TITLE
docs: refine Doxygen comments

### DIFF
--- a/include/kurlyk/core/NetworkWorker.hpp
+++ b/include/kurlyk/core/NetworkWorker.hpp
@@ -26,15 +26,19 @@ namespace kurlyk::core {
             return *instance;
         }
 
-        /// \brief
-        /// \param handler
+        /// \brief Registers a callback for handling network errors.
+        /// \param handler Function invoked when an error is dispatched.
         void add_error_handler(ErrorHandler handler) {
             std::lock_guard<std::mutex> lock(m_error_handlers_mutex);
             m_error_handlers.push_back(std::move(handler));
         }
 
-        /// \brief
-        /// \param
+        /// \brief Dispatches an exception to all registered error handlers.
+        /// \param e   The thrown exception.
+        /// \param msg Additional context message.
+        /// \param file Source file where the error occurred.
+        /// \param line Line number where the error occurred.
+        /// \param func Function name where the error occurred.
         void handle_error(
                 const std::exception& e,
                 const char* msg,
@@ -207,10 +211,10 @@ namespace kurlyk::core {
         bool                        m_is_worker_started = false;        ///< Flag indicating if the worker thread is started.
         mutable std::mutex          m_tasks_list_mutex;                 ///< Mutex for protecting access to the task list.
         std::list<std::function<void()>> m_tasks_list;                  ///< List of tasks queued for processing by the worker.
-        mutable std::mutex          m_managers_mutex;                   ///<
-        std::vector<INetworkTaskManager*> m_managers;                   ///<
-        std::mutex                  m_error_handlers_mutex;             ///<
-        std::vector<ErrorHandler>   m_error_handlers;                   ///<
+        mutable std::mutex          m_managers_mutex;                   ///< Mutex protecting access to registered managers.
+        std::vector<INetworkTaskManager*> m_managers;                   ///< List of registered network task managers.
+        std::mutex                  m_error_handlers_mutex;             ///< Mutex guarding the error handler list.
+        std::vector<ErrorHandler>   m_error_handlers;                   ///< Collection of registered error handlers.
 
 
         /// \brief Private constructor to enforce singleton pattern.

--- a/include/kurlyk/http/HttpClient.hpp
+++ b/include/kurlyk/http/HttpClient.hpp
@@ -637,8 +637,8 @@ namespace kurlyk {
     private:
         HttpRequest m_request;  ///< The request object used for configuring and sending requests.
         std::string m_host;     ///< The base host URL for the HTTP client.
-        bool is_general_limit_owned = false;
-        bool is_specific_limit_owned = false;
+        bool is_general_limit_owned = false; ///< Flag indicating if the client owns the general rate limit.
+        bool is_specific_limit_owned = false; ///< Flag indicating if the client owns the specific rate limit.
 
         /// \brief Adds the request to the request manager and notifies the worker to process it.
         /// \param request_ptr The HTTP request to be sent.
@@ -652,9 +652,9 @@ namespace kurlyk {
             return status;
         }
 
-        /// \brief
-        /// \param
-        /// \param
+        /// \brief Safely sets the response value on the given promise.
+        /// \param promise Promise that receives the HTTP response.
+        /// \param response Completed HTTP response to forward to the caller.
         static void safe_set_response(
                 std::shared_ptr<std::promise<HttpResponsePtr>> promise,
                 HttpResponsePtr response) {
@@ -674,10 +674,10 @@ namespace kurlyk {
             }
         }
 
-        /// \brief
-        /// \param
-        /// \param
-        /// \param
+        /// \brief Submits a request and propagates any failure to the provided promise.
+        /// \param promise Promise to signal upon success or failure.
+        /// \param request_ptr Prepared HTTP request to enqueue.
+        /// \param callback Callback executed when the request completes.
         void safe_submit_request(
                 std::shared_ptr<std::promise<HttpResponsePtr>> promise,
                 std::unique_ptr<HttpRequest> request_ptr,

--- a/include/kurlyk/http/HttpRequestManager/HttpBatchRequestHandler.hpp
+++ b/include/kurlyk/http/HttpRequestManager/HttpBatchRequestHandler.hpp
@@ -83,7 +83,7 @@ namespace kurlyk {
 
     private:
         CURLM* m_multi_handle = nullptr; ///< libcurl multi handle.
-        std::vector<std::unique_ptr<HttpRequestHandler>> m_handlers; // CURL handles
+        std::vector<std::unique_ptr<HttpRequestHandler>> m_handlers; ///< Collection of active request handlers.
         std::list<std::unique_ptr<HttpRequestContext>>   m_failed_requests; ///< List of failed request contexts.
 
         /// \brief Handles the completion of a single request.

--- a/include/kurlyk/http/data/HttpResponse.hpp
+++ b/include/kurlyk/http/data/HttpResponse.hpp
@@ -16,7 +16,7 @@ namespace kurlyk {
         std::error_code error_code;         ///< Error code indicating issues with the response, if any.
         std::string     error_message;      ///< Error message detailing the issue, if any.
         long            status_code = 0;    ///< HTTP status code of the response (e.g., 200, 404).
-        long            retry_attempt = 0;  ///<
+        long            retry_attempt = 0;  ///< Number of retry attempts performed for this request.
         bool            ready = false;      ///< Indicates if the response is ready to be processed.
         
         // --- Timing metrics (all values in seconds) ---

--- a/include/kurlyk/startup/runtime.hpp
+++ b/include/kurlyk/startup/runtime.hpp
@@ -39,8 +39,8 @@ namespace kurlyk {
         core::NetworkWorker::get_instance().shutdown();
     }
 
-    /// \brief
-    /// \param
+    /// \brief Registers a global error handler for the network worker.
+    /// \param handler Callback invoked when an error is reported.
     inline void add_error_handler(::kurlyk::core::NetworkWorker::ErrorHandler handler) {
         ::kurlyk::core::NetworkWorker::get_instance().add_error_handler(std::move(handler));
     }

--- a/include/kurlyk/websocket/WebSocketClient.hpp
+++ b/include/kurlyk/websocket/WebSocketClient.hpp
@@ -43,7 +43,7 @@ namespace kurlyk {
         /// \param reconnect Enables automatic reconnection if true.
         /// \param verify_cert If true, verifies the server’s certificate and hostname according to RFC 2818.
         /// \param ca_file Path to the Root CA certificate file.
-        /// \param rpm Запросы в минуту (RPM)
+        /// \param rpm Requests per minute (RPM).
         WebSocketClient(
                 const std::string& url,
                 const Headers& headers = Headers(),

--- a/include/kurlyk/websocket/client/Emscripten/EmscriptenWebSocketClientAdapter.hpp
+++ b/include/kurlyk/websocket/client/Emscripten/EmscriptenWebSocketClientAdapter.hpp
@@ -187,30 +187,30 @@ namespace kurlyk {
 
         /// \brief State for the WebSocket connection.
         enum class WebSocketState {
-            START,              ///< Инициализация
-            CONNECTING,         ///< Ожидание подключения
-            WORKING,            ///< Работа в процессе
-            DISCONNECTING,      ///< Ожидание отключения
-            STOPPED             ///< Остановка
+            START,              ///< Initialization.
+            CONNECTING,         ///< Waiting for connection establishment.
+            WORKING,            ///< Connection is active.
+            DISCONNECTING,      ///< Waiting for disconnection.
+            STOPPED             ///< Connection stopped.
         } m_ws_state = WebSocketState::START;
 
-        /// \brief
+        /// \brief Finite state machine states controlling client workflow.
         enum class FsmState {
-            INIT,               ///< Инициализация
-            CONNECTING,         ///< Ожидание подключения
-            WORKING,            ///< Работа в процессе
-            RECONNECTING,       ///< Попытка переподключения
-            STOPPED             ///< Остановка
+            INIT,               ///< Initialization.
+            CONNECTING,         ///< Waiting for connection.
+            WORKING,            ///< Connection active.
+            RECONNECTING,       ///< Attempting reconnection.
+            STOPPED             ///< Stopped.
         } m_fsm_state = FsmState::INIT;
 
         /// \brief Represents events in the finite state machine.
         enum class FsmEvent {
-            RequestConnect,     ///< Запрос на подключение
-            RequestDisconnect,  ///< Запрос на отключение
-            ConnectionOpened,   ///< Соединение открыто
-            ConnectionClosed,   ///< Соединение закрыто
-            ConnectionError,    ///< Ошибка соединения
-            UpdateConfig
+            RequestConnect,     ///< Request to connect.
+            RequestDisconnect,  ///< Request to disconnect.
+            ConnectionOpened,   ///< Connection opened.
+            ConnectionClosed,   ///< Connection closed.
+            ConnectionError,    ///< Connection error occurred.
+            UpdateConfig        ///< Configuration update requested.
         };
 
         std::function<void(std::unique_ptr<WebSocketEventData>)> m_on_event;


### PR DESCRIPTION
## Summary
- clarify NetworkWorker error dispatch and member docs
- document helper functions in HttpClient and HttpBatchRequestHandler
- translate and complete WebSocket FSM comments

## Testing
- `g++ -std=c++17 -Iinclude -DKURLYK_WEBSOCKET_SUPPORT=0 examples/simple_http_request_example.cpp -lcurl -lssl -lcrypto -lpthread -o /tmp/simple_http_request_example`

------
https://chatgpt.com/codex/tasks/task_e_68952912a24c832c84337246468c9a5d