### PR TITLE
example: replace pauses with std::cin.get and fix comments

### DIFF
--- a/examples/async_multi_request_example.cpp
+++ b/examples/async_multi_request_example.cpp
@@ -72,7 +72,7 @@ int main() {
     std::thread async_thread(handle_async_responses, std::ref(futures));
     async_thread.join(); // Wait for the async thread to complete
 
-    //std::system("pause");
+    // std::cin.get();
     KURLYK_PRINT << "All requests completed." << std::endl;
 
     kurlyk::deinit();

--- a/examples/bybit_funding_history_example.cpp
+++ b/examples/bybit_funding_history_example.cpp
@@ -42,7 +42,7 @@ int main() {
             print_response(response);
         });
 
-    std::system("pause");
+    std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();
     return 0;

--- a/examples/http_client_proxy_example.cpp
+++ b/examples/http_client_proxy_example.cpp
@@ -74,7 +74,7 @@ int main() {
         print_response(response);
     });
 
-    std::system("pause");
+    std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();
     return 0;

--- a/examples/nested_http_requests_example.cpp
+++ b/examples/nested_http_requests_example.cpp
@@ -1,4 +1,5 @@
 #include <kurlyk.hpp>
+#include <iostream>
 
 // Helper function to print the response details
 void print_response(const kurlyk::HttpResponsePtr& response) {
@@ -39,7 +40,7 @@ int main() {
             }
         });
 
-    std::system("pause");
+    std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();
     return 0;

--- a/examples/redirect_handling_example.cpp
+++ b/examples/redirect_handling_example.cpp
@@ -24,7 +24,7 @@ int main() {
     client.set_retry_attempts(3, 1000);    // 3 retry attempts, 1-second delay between retries
     client.set_rate_limit(5, 1000);        // Rate limit: 5 requests per second
     // Configure the maximum number of redirects
-    int redirect_count = 15;  // For example, try 5 redirects
+    int redirect_count = 15;  // Allow up to 15 redirects
     client.set_max_redirects(redirect_count);
 
     // Redirect handling - GET request with redirections
@@ -34,7 +34,7 @@ int main() {
            print_response(response);
        });
 
-    std::system("pause");
+    std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();
     return 0;

--- a/examples/websocket_client_lifecycle_test.cpp
+++ b/examples/websocket_client_lifecycle_test.cpp
@@ -34,7 +34,7 @@ void test_connect_disconnect(int n) {
             client.connect();
         } // Client 1 exits scope here
 
-        // Second client: connects, stays connected for 10 seconds, then exits scope
+        // Second client: connects, stays connected for 60 seconds, then exits scope
         {
             kurlyk::WebSocketClient client("wss://echo-websocket.fly.dev/");
             const long rate_limit_id = client.add_rate_limit_rps(2);
@@ -70,7 +70,7 @@ void test_connect_disconnect(int n) {
             std::this_thread::sleep_for(std::chrono::seconds(60));
             KURLYK_PRINT << "Client 2: Disconnecting..." << std::endl;
             client.disconnect_and_wait();
-        } // Client 2 exits scope after 10 seconds
+        } // Client 2 exits scope after 60 seconds
     }
 }
 

--- a/examples/websocket_independent_clients_example.cpp
+++ b/examples/websocket_independent_clients_example.cpp
@@ -61,9 +61,9 @@ void test_connect_disconnect(int n) {
                         break;
                 };
             });
-            KURLYK_PRINT << "Client 1: Connecting..." << std::endl;
+            KURLYK_PRINT << "Client 2: Connecting..." << std::endl;
             client2.connect_and_wait();
-            std::this_thread::sleep_for(std::chrono::seconds(10)); // Подключён 10 секунд
+            std::this_thread::sleep_for(std::chrono::seconds(10)); // Остаётся подключённым 10 секунд
             KURLYK_PRINT << "Client 2: Disconnecting..." << std::endl;
             client2.disconnect_and_wait();
             KURLYK_PRINT << "Client 2: End" << std::endl;


### PR DESCRIPTION
## Summary
- replace Windows-specific pause calls with portable `std::cin.get()` in examples
- clarify misleading comments and log messages

## Testing
- `g++ -std=c++17 examples/simple_http_request_example.cpp -Iinclude -pthread -lcurl -DKURLYK_WEBSOCKET_SUPPORT=0 -o simple_http_request_example`
- `./simple_http_request_example`


------
https://chatgpt.com/codex/tasks/task_e_6895391fff18832c9debc1a1179e66e9