### PR TITLE
docs(examples): refine KURLYK_PRINT comments

### DIFF
--- a/examples/bybit_funding_history_example.cpp
+++ b/examples/bybit_funding_history_example.cpp
@@ -1,7 +1,7 @@
 #include <kurlyk.hpp>
 #include <iostream>
 
-// Helper function to print the response details
+// Thread-safe logging of response details
 void print_response(const kurlyk::HttpResponsePtr& response) {
     KURLYK_PRINT << "Headers:" << std::endl;
     for (const auto& header : response->headers) {

--- a/examples/nested_http_requests_example.cpp
+++ b/examples/nested_http_requests_example.cpp
@@ -1,7 +1,7 @@
 #include <kurlyk.hpp>
 #include <iostream>
 
-// Helper function to print the response details
+// Thread-safe logging of response details
 void print_response(const kurlyk::HttpResponsePtr& response) {
     KURLYK_PRINT
         << "Response received:" << std::endl

--- a/examples/websocket_echo_example.cpp
+++ b/examples/websocket_echo_example.cpp
@@ -8,10 +8,10 @@ int main() {
             case kurlyk::WebSocketEventType::WS_OPEN:
                 KURLYK_PRINT << "Connection opened" << std::endl;
 
-                // Output HTTP version
+                // Log HTTP version
                 KURLYK_PRINT << "HTTP Version: " << event->sender->get_http_version() << std::endl;
 
-                // Output headers
+                // Log headers
                 KURLYK_PRINT << "Headers:" << std::endl;
                 for (const auto& header : event->sender->get_headers()) {
                     KURLYK_PRINT << header.first << ": " << header.second << std::endl;


### PR DESCRIPTION
## Summary
- Clarify comments around KURLYK_PRINT in WebSocket echo sample
- Note thread-safe logging in Bybit funding and nested HTTP request helpers

## Testing
- `g++ examples/nested_http_requests_example.cpp -Iinclude -std=c++17 -pthread -lcurl -lssl -lcrypto -DKURLYK_WEBSOCKET_SUPPORT=0 -o nested_example`
- `g++ examples/websocket_echo_example.cpp -Iinclude -std=c++17 -pthread -lcurl -lssl -lcrypto -o websocket_echo_example` *(fails: client_ws.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689540ecadf4832cb2ff299ccbf7b59b