### PR TITLE
refactor(examples): clarify console output messages

### DIFF
--- a/examples/async_multi_request_example.cpp
+++ b/examples/async_multi_request_example.cpp
@@ -23,7 +23,7 @@ void handle_async_responses(std::vector<std::future<kurlyk::HttpResponsePtr>>& f
             print_response(response);
         }
     } catch(...) {
-        KURLYK_PRINT << "Error." << std::endl;
+        KURLYK_PRINT << "Error while retrieving async responses." << std::endl;
         throw;
     }
     KURLYK_PRINT << "All async requests completed in separate thread." << std::endl;

--- a/examples/bybit_funding_history_example.cpp
+++ b/examples/bybit_funding_history_example.cpp
@@ -42,6 +42,7 @@ int main() {
             print_response(response);
         });
 
+    KURLYK_PRINT << "Press Enter to exit..." << std::endl;
     std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();

--- a/examples/cancel_http_requests.cpp
+++ b/examples/cancel_http_requests.cpp
@@ -26,7 +26,7 @@ int main() {
                      << "\n  Exception: " << ex.what()
                      << "\n  Function: " << func
                      << "\n  File: " << file
-                     << "\n  Line: " << line;
+                     << "\n  Line: " << line << std::endl;
     });
 
     // Sending a GET request using the first function (callback-based)
@@ -80,7 +80,7 @@ int main() {
     // ---
 
     for (int n = 0; n < 10; ++n) {
-        KURLYK_PRINT << "N #" << n << "\n";
+        KURLYK_PRINT << "Iteration " << n << std::endl;
 
         uint32_t limit_id = kurlyk::create_rate_limit_rps(2);
 
@@ -97,7 +97,7 @@ int main() {
             client->set_connect_timeout(5);
             client->set_retry_attempts(3, 1000);
 
-            KURLYK_PRINT << "Client #" << i << "\n";
+            KURLYK_PRINT << "Client #" << i << std::endl;
 
             for (int j = 0; j < num_req; ++j) {
                 if (j % 3 == 0) {
@@ -118,7 +118,7 @@ int main() {
 
             auto& client = clients[i];
 
-            KURLYK_PRINT << "Client #" << i << " using HEAD request\n";
+            KURLYK_PRINT << "Client #" << i << " using HEAD request" << std::endl;
             client->set_head_only(true);
             futures.emplace_back(client->get("/delay/2", kurlyk::QueryParams(), kurlyk::Headers()));
             client->set_head_only(false);
@@ -140,7 +140,7 @@ int main() {
             }
         }
 
-        KURLYK_PRINT << "Result:\n";
+        KURLYK_PRINT << "Results:" << std::endl;
         for (int i = 0; i < num_clients; ++i) {
             try {
                 auto response = futures[i].get();
@@ -157,7 +157,7 @@ int main() {
         kurlyk::remove_limit(limit_id);
     }
 
-    KURLYK_PRINT << "Exit?\n";
+    KURLYK_PRINT << "Press Enter to exit..." << std::endl;
     std::cin.get();
 
     kurlyk::deinit();

--- a/examples/chatgpt_request_example.cpp
+++ b/examples/chatgpt_request_example.cpp
@@ -52,21 +52,22 @@ int main() {
         client.set_retry_attempts(1, 5000);
         client.set_verbose(true);
 
-        std::cout << "request_body: " << request_body.dump(4) << std::endl;
+        KURLYK_PRINT << "Request body: " << request_body.dump(4) << std::endl;
 
         // Send the POST request with JSON body
         auto future = client.post("/v1/chat/completions", {}, headers, request_body.dump());
 
         auto response = future.get();
         if (response->ready && response->status_code == 200) {
-            std::cout << "Response from ChatGPT: " << response->content << std::endl;
+            KURLYK_PRINT << "Response from ChatGPT: " << response->content << std::endl;
         } else {
-            std::cerr << "Error: " << response->status_code << "\n" << response->error_code.message() << std::endl;
-            std::cout << "Response: " << response->content << std::endl;
+            KURLYK_PRINT << "Error: " << response->status_code
+                         << " - " << response->error_code.message() << std::endl;
+            KURLYK_PRINT << "Response: " << response->content << std::endl;
         }
 
     } catch (const std::exception& e) {
-        std::cerr << "Error: " << e.what() << std::endl;
+        KURLYK_PRINT << "Error: " << e.what() << std::endl;
     }
 
     kurlyk::deinit();  // Deinitialize the kurlyk library

--- a/examples/http_client_future_example.cpp
+++ b/examples/http_client_future_example.cpp
@@ -36,6 +36,7 @@ int main() {
         << "Status Code: " << response_func->status_code << std::endl
         << "----------------------------------------" << std::endl;
 
+    KURLYK_PRINT << "Press Enter to exit..." << std::endl;
     std::cin.get();
 
     kurlyk::deinit();

--- a/examples/http_client_proxy_example.cpp
+++ b/examples/http_client_proxy_example.cpp
@@ -74,6 +74,7 @@ int main() {
         print_response(response);
     });
 
+    KURLYK_PRINT << "Press Enter to exit..." << std::endl;
     std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();

--- a/examples/nested_http_requests_example.cpp
+++ b/examples/nested_http_requests_example.cpp
@@ -40,6 +40,7 @@ int main() {
             }
         });
 
+    KURLYK_PRINT << "Press Enter to exit..." << std::endl;
     std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();

--- a/examples/redirect_handling_example.cpp
+++ b/examples/redirect_handling_example.cpp
@@ -28,12 +28,13 @@ int main() {
     client.set_max_redirects(redirect_count);
 
     // Redirect handling - GET request with redirections
-    std::cout << "Sending GET request to /absolute-redirect/" << redirect_count << "..." << std::endl;
+    KURLYK_PRINT << "Sending GET request to /absolute-redirect/" << redirect_count << "..." << std::endl;
     client.get("/absolute-redirect/" + std::to_string(redirect_count), kurlyk::QueryParams(), kurlyk::Headers(),
        [](const kurlyk::HttpResponsePtr response) {
            print_response(response);
        });
 
+    KURLYK_PRINT << "Press Enter to exit..." << std::endl;
     std::cin.get();
     client.cancel_requests();
     kurlyk::deinit();

--- a/examples/utility_functions_example.cpp
+++ b/examples/utility_functions_example.cpp
@@ -8,47 +8,51 @@ int main() {
         std::string original = "Hello World! How are you?";
         std::string encoded = kurlyk::utils::percent_encode(original);
         std::string decoded = kurlyk::utils::percent_decode(encoded);
-        std::cout << "Original: " << original << "\n";
-        std::cout << "Encoded: " << encoded << "\n";
-        std::cout << "Decoded: " << decoded << "\n";
+        KURLYK_PRINT << "Original: " << original << std::endl;
+        KURLYK_PRINT << "Encoded: " << encoded << std::endl;
+        KURLYK_PRINT << "Decoded: " << decoded << std::endl;
 
         // Example 2: Validate email
         std::vector<std::string> emails = {"valid@example.com", "invalid-email", "user@domain.ruf"};
         for (const auto& email : emails) {
-            std::cout << "Email: " << email << " is valid: " << std::boolalpha << kurlyk::utils::is_valid_email_id(email) << "\n";
+            KURLYK_PRINT << "Email: " << email << " is valid: " << std::boolalpha
+                         << kurlyk::utils::is_valid_email_id(email) << std::endl;
         }
 
         // Example 3: Extract protocol from URL
         std::string url = "https://example.com/path?query=value";
         std::string protocol = kurlyk::utils::extract_protocol(url);
-        std::cout << "Protocol in URL: " << protocol << "\n";
+        KURLYK_PRINT << "Protocol in URL: " << protocol << std::endl;
 
         // Example 4: Convert query parameters to a query string
         kurlyk::QueryParams query = {{"key1", "value1"}, {"key2", "value2"}};
         std::string query_string = kurlyk::utils::to_query_string(query);
-        std::cout << "Query string: " << query_string << "\n";
+        KURLYK_PRINT << "Query string: " << query_string << std::endl;
 
         // Example 5: Validate domain and path
         std::string domain = "example.com";
         std::string path = "/valid/path";
-        std::cout << "Domain " << domain << " is valid: " << std::boolalpha << kurlyk::utils::is_valid_domain(domain) << "\n";
-        std::cout << "Path " << path << " is valid: " << std::boolalpha << kurlyk::utils::is_valid_path(path) << "\n";
+        KURLYK_PRINT << "Domain " << domain << " is valid: " << std::boolalpha
+                      << kurlyk::utils::is_valid_domain(domain) << std::endl;
+        KURLYK_PRINT << "Path " << path << " is valid: " << std::boolalpha
+                     << kurlyk::utils::is_valid_path(path) << std::endl;
 
         // Example 6: Validate URL
         std::vector<std::string> protocols = {"http", "https"};
-        std::cout << "URL " << url << " is valid: " << std::boolalpha << kurlyk::utils::is_valid_url(url, protocols) << "\n";
+        KURLYK_PRINT << "URL " << url << " is valid: " << std::boolalpha
+                     << kurlyk::utils::is_valid_url(url, protocols) << std::endl;
 
         // Example 7: Convert User-Agent to sec-ch-ua
         std::string user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
         std::string sec_ch_ua = kurlyk::utils::convert_user_agent_to_sec_ch_ua(user_agent);
-        std::cout << "sec-ch-ua header: " << sec_ch_ua << "\n";
+        KURLYK_PRINT << "sec-ch-ua header: " << sec_ch_ua << std::endl;
 
         // Example 8: Get executable path
         std::string exe_path = kurlyk::utils::get_exec_dir();
-        std::cout << "Executable path: " << exe_path << "\n";
+        KURLYK_PRINT << "Executable path: " << exe_path << std::endl;
 
     } catch (const std::exception& e) {
-        std::cerr << "Error: " << e.what() << std::endl;
+        KURLYK_PRINT << "Error: " << e.what() << std::endl;
     }
 
     return 0;

--- a/examples/websocket_client_lifecycle_test.cpp
+++ b/examples/websocket_client_lifecycle_test.cpp
@@ -38,7 +38,7 @@ void test_connect_disconnect(int n) {
         {
             kurlyk::WebSocketClient client("wss://echo-websocket.fly.dev/");
             const long rate_limit_id = client.add_rate_limit_rps(2);
-            KURLYK_PRINT << "rate_limit_id " << rate_limit_id << std::endl;
+            KURLYK_PRINT << "Assigned rate limit ID: " << rate_limit_id << std::endl;
             client.on_event([rate_limit_id](std::unique_ptr<kurlyk::WebSocketEventData> event) {
                 static int counter = 0;
                 switch (event->event_type) {

--- a/examples/websocket_echo_example.cpp
+++ b/examples/websocket_echo_example.cpp
@@ -60,6 +60,6 @@ int main() {
     KURLYK_PRINT << "Disconnecting..." << std::endl;
     client.disconnect_and_wait();
 
-    KURLYK_PRINT << "End" << std::endl;
+    KURLYK_PRINT << "Program finished." << std::endl;
     return 0;
 }

--- a/examples/websocket_independent_clients_example.cpp
+++ b/examples/websocket_independent_clients_example.cpp
@@ -35,7 +35,7 @@ void test_connect_disconnect(int n) {
             std::this_thread::sleep_for(std::chrono::seconds(5)); // Дождаться приёма сообщения
             KURLYK_PRINT << "Client 1: Disconnecting..." << std::endl;
             client1.disconnect_and_wait();
-            KURLYK_PRINT << "Client 1: End" << std::endl;
+            KURLYK_PRINT << "Client 1: Session ended." << std::endl;
         });
 
         // Второй клиент: подключается, остаётся подключённым, периодически отправляет сообщения.
@@ -66,7 +66,7 @@ void test_connect_disconnect(int n) {
             std::this_thread::sleep_for(std::chrono::seconds(10)); // Остаётся подключённым 10 секунд
             KURLYK_PRINT << "Client 2: Disconnecting..." << std::endl;
             client2.disconnect_and_wait();
-            KURLYK_PRINT << "Client 2: End" << std::endl;
+            KURLYK_PRINT << "Client 2: Session ended." << std::endl;
         });
 
         // Подождать завершения работы потоков клиентов перед повторной итерацией
@@ -79,6 +79,6 @@ void test_connect_disconnect(int n) {
 int main() {
     int repeat_count = 3; // Количество повторов цикла подключения/отключения
     test_connect_disconnect(repeat_count);
-    KURLYK_PRINT << "End" << std::endl;
+    KURLYK_PRINT << "All iterations completed." << std::endl;
     return 0;
 }


### PR DESCRIPTION
## Summary
- make console output descriptive across examples
- prompt before waiting on `std::cin.get()`
- standardize on `KURLYK_PRINT` for logging

## Testing
- `g++ examples/utility_functions_example.cpp -Iinclude -std=c++17 -pthread -lcurl -lssl -lcrypto -DKURLYK_WEBSOCKET_SUPPORT=0 -o utility_example`


------
https://chatgpt.com/codex/tasks/task_e_689542d79198832cb1f4fcc5a568429c