### PR TITLE
fix: inline utility header functions

### DIFF
--- a/include/kurlyk/utils/email_utils.hpp
+++ b/include/kurlyk/utils/email_utils.hpp
@@ -10,7 +10,7 @@ namespace kurlyk::utils {
     /// \brief Validates an email address format.
     /// \param str The email address to validate.
     /// \return True if the email address format is valid, false otherwise.
-    bool is_valid_email_id(const std::string &str) {
+    inline bool is_valid_email_id(const std::string &str) {
         // Regular expression to validate an email address format
         static const std::regex email_regex(
             R"(^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$)"

--- a/include/kurlyk/utils/encoding_utils.hpp
+++ b/include/kurlyk/utils/encoding_utils.hpp
@@ -11,7 +11,7 @@ namespace kurlyk::utils {
     /// \brief Converts a UTF-8 string to an ANSI string (Windows-specific).
     /// \param utf8 The UTF-8 encoded string.
     /// \return The converted ANSI string.
-    std::string utf8_to_ansi(const std::string& utf8) noexcept {
+    inline std::string utf8_to_ansi(const std::string& utf8) noexcept {
         int n_len = MultiByteToWideChar(CP_UTF8, 0, utf8.c_str(), -1, NULL, 0);
         if (n_len == 0) return {};
 

--- a/include/kurlyk/utils/http_parser.hpp
+++ b/include/kurlyk/utils/http_parser.hpp
@@ -38,7 +38,7 @@ namespace kurlyk::utils {
     /// \param query The multimap containing query fields and values.
     /// \param prefix Optional prefix for the query string.
     /// \return The encoded query string.
-    std::string to_query_string(
+    inline std::string to_query_string(
             const QueryParams &query,
             const std::string &prefix = std::string()) noexcept {
         if (query.empty()) return std::string();
@@ -73,7 +73,7 @@ namespace kurlyk::utils {
     /// \param query The multimap containing query fields and values.
     /// \param prefix Optional prefix for the query string.
     /// \return The encoded query string.
-    std::string to_query_string(
+    inline std::string to_query_string(
             const QueryParams &query,
             const std::string &prefix = std::string()) noexcept {
         std::string result(prefix);
@@ -95,7 +95,7 @@ namespace kurlyk::utils {
     /// \brief Converts a CaseInsensitiveMultimap to a string format suitable for HTTP Cookie headers.
     /// \param cookies The multimap containing key-value pairs.
     /// \return A string formatted as a Cookie header.
-    std::string to_cookie_string(const CaseInsensitiveMultimap& cookies) {
+    inline std::string to_cookie_string(const CaseInsensitiveMultimap& cookies) {
         std::string result;
 
         for (auto it = cookies.begin(); it != cookies.end(); ++it) {
@@ -111,7 +111,7 @@ namespace kurlyk::utils {
     /// \brief Converts a CaseInsensitiveMultimap to a string format suitable for HTTP Cookie headers.
     /// \param cookies The multimap containing key-value pairs.
     /// \return A string formatted as a Cookie header.
-    std::string to_cookie_string(const Cookies& cookies) {
+    inline std::string to_cookie_string(const Cookies& cookies) {
         std::string result;
 
         for (auto it = cookies.begin(); it != cookies.end(); ++it) {
@@ -135,7 +135,7 @@ namespace kurlyk::utils {
     /// \brief Parses a cookie string into a Cookies object.
     /// \param cookie The cookie string to parse.
     /// \return A Cookies object containing parsed cookies.
-    Cookies parse_cookie(std::string cookie) {
+    inline Cookies parse_cookie(std::string cookie) {
         Cookies cookies;
         std::vector<std::string> list_fragment;
         cookie += ";";

--- a/include/kurlyk/utils/http_utils.hpp
+++ b/include/kurlyk/utils/http_utils.hpp
@@ -10,7 +10,7 @@ namespace kurlyk::utils {
     /// \brief Removes the first occurrence of "https://" or "http://" from the given URL.
     /// \param url The URL from which to remove the substring.
     /// \return std::string The modified URL with the first occurrence of "https://" or "http://" removed.
-    std::string remove_http_prefix(const std::string& url) {
+    inline std::string remove_http_prefix(const std::string& url) {
         const std::string https_prefix = "https://";
         const std::string http_prefix = "http://";
 

--- a/include/kurlyk/utils/path_utils.hpp
+++ b/include/kurlyk/utils/path_utils.hpp
@@ -13,7 +13,7 @@ namespace kurlyk::utils {
 
     /// \brief Retrieves the directory of the executable file.
     /// \return A string containing the directory path of the executable.
-    std::string get_exec_dir() {
+    inline std::string get_exec_dir() {
 #       if defined(_WIN32)
         std::vector<wchar_t> buffer(MAX_PATH);
         HMODULE hModule = GetModuleHandle(NULL);

--- a/include/kurlyk/utils/percent_encoding.hpp
+++ b/include/kurlyk/utils/percent_encoding.hpp
@@ -14,7 +14,7 @@ namespace kurlyk::utils {
     /// \brief Encodes a string using Percent Encoding according to RFC 3986.
     /// \param value The string to be encoded.
     /// \return The percent-encoded string.
-    std::string percent_encode(const std::string &value) noexcept {
+    inline std::string percent_encode(const std::string &value) noexcept {
         static const char hex_chars[] = "0123456789ABCDEF";
 
         std::string result;
@@ -36,7 +36,7 @@ namespace kurlyk::utils {
     /// \brief Decodes a Percent-Encoded string.
     /// \param value The percent-encoded string to be decoded.
     /// \return The decoded string.
-    std::string percent_decode(const std::string &value) noexcept {
+    inline std::string percent_decode(const std::string &value) noexcept {
         std::string result;
         result.reserve(value.size() / 3 + (value.size() % 3)); // Reserve minimum required size
 

--- a/include/kurlyk/utils/url_utils.hpp
+++ b/include/kurlyk/utils/url_utils.hpp
@@ -24,7 +24,7 @@ namespace kurlyk::utils {
     /// \brief Removes the first occurrence of "wss://" or "ws://" from the given URL.
     /// \param url The URL from which to remove the substring.
     /// \return std::string The modified URL with the first occurrence of "wss://" or "ws://" removed.
-    std::string remove_ws_prefix(const std::string& url) {
+    inline std::string remove_ws_prefix(const std::string& url) {
         const std::string wss_prefix = "wss://";
         const std::string ws_prefix = "ws://";
 
@@ -52,14 +52,14 @@ namespace kurlyk::utils {
     /// \param url The URL string to check.
     /// \param scheme The scheme (e.g., "http") to check.
     /// \return True if the URL starts with the specified scheme, otherwise false.
-    bool is_valid_scheme(const std::string& url, const std::string& scheme) {
+    inline bool is_valid_scheme(const std::string& url, const std::string& scheme) {
         return url.compare(0, scheme.length(), scheme) == 0;
     }
 	
     /// \brief Validates if a domain name is correctly formatted.
     /// \param domain The domain string to validate.
     /// \return True if the domain is valid, otherwise false.
-    bool is_valid_domain(const std::string& domain) {
+    inline bool is_valid_domain(const std::string& domain) {
         size_t dot_pos = domain.find('.');
 
         if (dot_pos == std::string::npos ||
@@ -86,7 +86,7 @@ namespace kurlyk::utils {
     /// \brief Checks if a path is correctly formatted.
     /// \param path The path string to validate.
     /// \return True if the path is valid, otherwise false.
-    bool is_valid_path(const std::string& path) {
+    inline bool is_valid_path(const std::string& path) {
         if (path.empty() || path[0] != '/') return false;
         for (char ch : path) {
             if (!isalnum(ch) && ch != '/' && ch != '-' && ch != '_') {
@@ -99,7 +99,7 @@ namespace kurlyk::utils {
     /// \brief Validates if a query string is correctly formatted.
     /// \param query The query string to validate.
     /// \return True if the query string is valid, otherwise false.
-    bool is_valid_query(const std::string& query) {
+    inline bool is_valid_query(const std::string& query) {
         if (query.empty() || query[0] != '?') {
             return false;
         }
@@ -123,7 +123,7 @@ namespace kurlyk::utils {
     /// \param url The URL string to validate.
     /// \param protocol A vector of valid protocol schemes.
     /// \return True if the URL is valid, otherwise false.
-    bool is_valid_url(const std::string& url, const std::vector<std::string>& protocol) {
+    inline bool is_valid_url(const std::string& url, const std::vector<std::string>& protocol) {
         size_t scheme_end = url.find("://");
         if (scheme_end == std::string::npos) {
             return false;

--- a/include/kurlyk/utils/user_agent_utils.hpp
+++ b/include/kurlyk/utils/user_agent_utils.hpp
@@ -10,7 +10,7 @@ namespace kurlyk::utils {
     /// \brief Converts a User-Agent string to a sec-ch-ua header value.
     /// \param user_agent The User-Agent string.
     /// \return The generated sec-ch-ua header value.
-    std::string convert_user_agent_to_sec_ch_ua(const std::string& user_agent) {
+    inline std::string convert_user_agent_to_sec_ch_ua(const std::string& user_agent) {
         // Regular expression to extract the browser name and version from User-Agent
         static const std::regex browser_regex(R"(Chrome/(\d+)\.\d+\.\d+\.\d+)");
         std::string version = "0";


### PR DESCRIPTION
## Summary
- mark reusable functions in percent encoding, HTTP helpers, and URL utilities as inline to avoid multiple definitions
- inline remaining helper functions in user agent, email, encoding, and path utilities to keep headers ODR-safe

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690daba15ddc832897da47ab78a7b754)