### PR TITLE
ci(docs): restore gh-pages publish action with no-change skip

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,7 +24,8 @@ jobs:
           sed -i "0,/VERSION_PLACEHOLDER/s//$TAG/" docs/mainpage.dox
       - name: Generate Documentation
         uses: mattnotmitt/doxygen-action@edge
-      - name: Publish generated content to GitHub Pages
+      - name: Check generated documentation changes
+        id: docs_diff
         env:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
         run: |
@@ -43,11 +44,16 @@ jobs:
           git add --all
 
           if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No documentation changes to publish."
-            exit 0
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Documentation changes detected."
           fi
-
-          git config user.name "${GITHUB_REPOSITORY_OWNER}"
-          git config user.email "${GITHUB_REPOSITORY_OWNER}@users.noreply.github.com"
-          git commit -m "Publish generated documentation"
-          git push origin gh-pages
+      - name: Publish generated content to GitHub Pages
+        if: steps.docs_diff.outputs.changed == 'true'
+        uses: tsunematsu21/actions-publish-gh-pages@v1.0.2
+        with:
+          dir: docs/html
+          branch: gh-pages
+          token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary

- restore `tsunematsu21/actions-publish-gh-pages@v1.0.2` for publishing generated Doxygen HTML
- keep the existing Doxygen generation step unchanged
- add a pre-publish diff check against `gh-pages`
- skip the publish action when generated docs are identical, avoiding false failures on `nothing to commit`

## Notes

This keeps the old publishing mechanism that produced the expected Doxygen output, while still preventing no-op publishes from failing the workflow.