### PR TITLE
test(deps): prefer pinned Simple-Web-Server submodule

### DIFF
--- a/cmake/deps/fallbacks/load_simple_web_server.cmake
+++ b/cmake/deps/fallbacks/load_simple_web_server.cmake
@@ -4,6 +4,19 @@ function(load_simple_web_server target)
 		set(USE_STANDALONE_ASIO ${KURLYK_USE_STANDALONE_ASIO}
 		  CACHE BOOL "Synchronization for Simple-Web-Server" FORCE)
 	endif()
+
+	set(simple_web_server_submodule_dir "${CMAKE_CURRENT_LIST_DIR}/../../../external/Simple-Web-Server")
+
+	if(EXISTS "${simple_web_server_submodule_dir}/server_http.hpp")
+		message(STATUS "Simple-Web-Server: using pinned submodule")
+		if (NOT TARGET simple_web_server)
+			add_library(simple_web_server INTERFACE)
+			target_include_directories(simple_web_server INTERFACE "${simple_web_server_submodule_dir}")
+		endif()
+		target_link_libraries(${target} PRIVATE simple_web_server)
+		return()
+	endif()
+
 	include(FetchContent)
 	FetchContent_Declare(simple_web_server
 		GIT_REPOSITORY https://gitlab.com/eidheim/Simple-Web-Server.git


### PR DESCRIPTION
## Summary

- prefer the existing `external/Simple-Web-Server` submodule for HTTP integration tests
- avoid using floating remote `master` when the pinned submodule is available
- keep the remote FetchContent fallback only as a fallback for builds without initialized submodules

## Notes

The successful CI run checked out `external/Simple-Web-Server` at `546895a93a29062bb178367b46c7afb72da9881e`, so using the submodule gives us the pinned revision that already passed the integration suite.