### PR TITLE
cmake: add Linux build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,27 @@ jobs:
         with:
           submodules: true
       - run: git submodule update --init --recursive
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev ninja-build
       - name: Build smoke test
         run: c++ tests/smoke/header_smoke.cpp -Iinclude -std=c++${{ matrix.std }} -o header_smoke
       - name: Run smoke test
         run: ./header_smoke
+      - name: Configure Linux CMake build
+        run: |
+          cmake -S . \
+                -B build-linux-cmake-${{ matrix.std }} \
+                -G Ninja \
+                -DCMAKE_CXX_STANDARD=${{ matrix.std }} \
+                -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+                -DKURLYK_BUILD_EXAMPLES=ON \
+                -DKURLYK_USE_FALLBACK_ASIO=ON \
+                -DKURLYK_USE_FALLBACK_SIMPLE_WS_SERVER=ON \
+                -Wno-dev
+      - name: Build Linux CMake examples
+        run: cmake --build build-linux-cmake-${{ matrix.std }}
 
   macos:
     runs-on: macos-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,15 @@ use_or_fetch_asio(kurlyk)
 include(cmake/deps/simple_ws_server.cmake)
 use_or_fetch_simple_ws_server(kurlyk)
 
-# зависимости от винды
+# OS-specific dependencies
 if (WIN32)
 	include(cmake/deps/win_deps.cmake)
+elseif(UNIX AND NOT APPLE)
+	include(cmake/deps/unix_deps.cmake)
 elseif(APPLE)
-	message(FATAL_ERROR "This option for MacOS is not supported yet.")
+	message(FATAL_ERROR "Full CMake build for macOS is not supported yet.")
 else()
-	message(FATAL_ERROR "This option for Linux is not supported yet.")
+	message(FATAL_ERROR "Unsupported platform.")
 endif()
 use_os_deps(kurlyk)
 

--- a/cmake/deps/curl.cmake
+++ b/cmake/deps/curl.cmake
@@ -1,4 +1,4 @@
-# for now only for MinGW
+# for now fallback binaries are only for Windows
 function(use_or_fetch_curl out_target)
 	
 	
@@ -11,7 +11,11 @@ function(use_or_fetch_curl out_target)
 	
 	
 	# if consumer has package
-	find_package(CURL 8.11.0 QUIET)
+	if(WIN32)
+		find_package(CURL 8.11.0 QUIET)
+	else()
+		find_package(CURL QUIET)
+	endif()
 	if (CURL_FOUND AND TARGET CURL::libcurl)
 		message(STATUS "CURL: using existing CURL::libcurl")
 		target_link_libraries(${out_target} INTERFACE CURL::libcurl)

--- a/cmake/deps/openssl.cmake
+++ b/cmake/deps/openssl.cmake
@@ -13,8 +13,12 @@ function(use_or_fetch_openssl out_target)
 	
 	
 	# if consumer has package
-	set(OPENSSL_USE_STATIC_LIBS OFF CACHE BOOL "" FORCE)
-	find_package(OpenSSL 3.4.0 QUIET)
+	if(WIN32)
+		set(OPENSSL_USE_STATIC_LIBS OFF CACHE BOOL "" FORCE)
+		find_package(OpenSSL 3.4.0 QUIET)
+	else()
+		find_package(OpenSSL QUIET)
+	endif()
 	if (OpenSSL_FOUND AND TARGET OpenSSL::SSL AND TARGET OpenSSL::Crypto)
 		message(STATUS "OpenSSL: using existing package OpenSSL::SSL / OpenSSL::Crypto")
 		target_link_libraries(${out_target} INTERFACE 

--- a/cmake/deps/unix_deps.cmake
+++ b/cmake/deps/unix_deps.cmake
@@ -1,0 +1,8 @@
+function(use_os_deps out_target)
+	find_package(Threads REQUIRED)
+	target_link_libraries(${out_target} INTERFACE Threads::Threads)
+
+	if(UNIX AND NOT APPLE)
+		target_link_libraries(${out_target} INTERFACE dl)
+	endif()
+endfunction()

--- a/include/kurlyk/websocket/client/SimpleWeb/SocketClient.hpp
+++ b/include/kurlyk/websocket/client/SimpleWeb/SocketClient.hpp
@@ -19,6 +19,14 @@
 #include <boost/asio/ssl.hpp>
 #endif
 
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <wincrypt.h>
+#endif
+
 namespace SimpleWeb {
     using WSS = asio::ssl::stream<asio::ip::tcp::socket>;
 
@@ -67,7 +75,6 @@ namespace SimpleWeb {
             if(verify_file.size() > 0) {
                 context.load_verify_file(verify_file);
             } else {
-                //context.set_default_verify_paths();
                 add_root_certificates();
             }
 
@@ -82,9 +89,10 @@ namespace SimpleWeb {
 
         /// \brief Adds root certificates from the system to the SSL context.
         ///
-        /// This method loads root certificates from the system certificate store and adds them to the SSL context.
-        /// It is used when no specific certificate authority file is provided.
+        /// On Windows, this method loads certificates from the system ROOT store.
+        /// On Unix-like systems, it uses OpenSSL default verify paths.
         void add_root_certificates() {
+#ifdef _WIN32
             X509_STORE* store = ::SSL_CTX_get_cert_store(context.native_handle());
             HCERTSTORE hCertStore = CertOpenSystemStore(0LL, "ROOT");
             if (!hCertStore) {
@@ -97,15 +105,17 @@ namespace SimpleWeb {
                 if (!certContext) {
                     break;
                 }
-                X509* x509 = d2i_X509(nullptr, (const unsigned char**)&certContext->pbCertEncoded,
-                                      certContext->cbCertEncoded);
+                const unsigned char* encoded = certContext->pbCertEncoded;
+                X509* x509 = d2i_X509(nullptr, &encoded, certContext->cbCertEncoded);
                 if (x509) {
                     X509_STORE_add_cert(store, x509);
                     X509_free(x509);
                 }
             }
-            CertFreeCertificateContext(certContext);
             CertCloseStore(hCertStore, 0);
+#else
+            context.set_default_verify_paths();
+#endif
         }
 
     protected:


### PR DESCRIPTION
## Summary

- add Unix platform dependencies through `Threads::Threads` and `dl`
- enable Linux in the top-level CMake project instead of failing with `This option for Linux is not supported yet`
- relax OpenSSL and CURL version constraints on non-Windows platforms so system packages can be used
- extend Linux CI to install `libcurl4-openssl-dev` / `libssl-dev`, configure CMake, and build all examples

## Notes

This PR intentionally does not add Linux integration runtime tests yet. It first makes the full CMake project configure and compile on Linux with HTTP/WebSocket enabled. If CI exposes Linux-specific source issues, they should be fixed in this PR before updating README support claims.