### PR TITLE
docs: fix Doxygen comment inaccuracies

### DIFF
--- a/include/kurlyk/http/HttpRequestManager/HttpRateLimiter.hpp
+++ b/include/kurlyk/http/HttpRequestManager/HttpRateLimiter.hpp
@@ -124,7 +124,7 @@ namespace kurlyk {
         /// \param in_flight_token Token identifying the in-flight request; 0 skips sequential checks.
         /// \param general_key Partition key for the general limit; empty means default state.
         /// \param specific_key Partition key for the specific limit; empty means default state.
-        /// \return True if the request is allowed, false otherwise (state unchanged on failure).
+        /// \return true if the request is allowed, false otherwise (state unchanged on failure).
         bool allow_request(
                 const HttpRateLimitHandlePtr& general_limit,
                 const HttpRateLimitHandlePtr& specific_limit,
@@ -264,7 +264,7 @@ namespace kurlyk {
         /// \param general_key Partition key for the general limit; empty means default shared state.
         /// \param specific_key Partition key for the specific limit; empty means default shared state.
         /// \return RateLimitDelay describing the maximum delay across both dimensions.
-        ///         `duration` is 0 if either dimension allows immediately.
+        ///         `duration` is 0 only when all present dimensions allow immediately.
         ///         `sequential_blocked` is true when at least one dimension is blocked
         ///         by a sequential in-flight request (`duration == Duration::max()`).
         template<typename Duration = std::chrono::milliseconds>
@@ -334,9 +334,9 @@ namespace kurlyk {
         /// \tparam Duration Duration type; defaults to `std::chrono::milliseconds`.
         /// \return RateLimitDelay where `duration` is the minimum positive delay across
         ///         all keys of all limits. If no limit reports a positive delay,
-        ///         `duration` is 0. `sequential_blocked` is true only when the minimum
-        ///         positive delay is `Duration::max()`, i.e. every live key is blocked
-        ///         by a sequential in-flight request.
+        ///         `duration` is 0. `sequential_blocked` is true when the selected
+        ///         positive delay is `Duration::max()`, meaning no finite positive
+        ///         delay was found among currently delayed keys.
         template<typename Duration = std::chrono::milliseconds>
         RateLimitDelay<Duration> time_until_any_limit_allows() {
             std::lock_guard<std::mutex> lock(m_mutex);
@@ -393,7 +393,7 @@ namespace kurlyk {
             std::unordered_map<std::string, KeyState> keys;       ///< Mutable state per partition key.
         };
 
-        /// \brief Physically removes LimitData from m_limits.
+        /// \brief Marks a limit as removed and erases it only when no key state remains.
         ///
         /// This method is intentionally private. It must be called only from
         /// HttpRateLimitHandle destruction path.
@@ -493,7 +493,7 @@ namespace kurlyk {
             ++state.count;
         }
 
-        /// \brief Releases an in-flight token from a specific key and erases the key if it becomes empty and stale.
+        /// \brief Releases an in-flight token from a specific key and erases the key if it has no runtime state.
         void release_key(LimitData& limit, const std::string& key, uint64_t token) {
             auto it = limit.keys.find(key);
             if (it == limit.keys.end()) {
@@ -563,7 +563,7 @@ namespace kurlyk {
             return period_duration - elapsed;
         }
 
-        /// \brief Erases keys that are empty and whose period has expired.
+        /// \brief Erases keys that are empty or whose period has expired.
         void gc_stale_keys(const time_point_t& now) {
             for (auto limit_it = m_limits.begin(); limit_it != m_limits.end(); ) {
                 auto& limit = limit_it->second;

--- a/include/kurlyk/http/data/HttpRequest.hpp
+++ b/include/kurlyk/http/data/HttpRequest.hpp
@@ -3,16 +3,16 @@
 #define _KURLYK_HTTP_REQUEST_HPP_INCLUDED
 
 /// \file HttpRequest.hpp
-/// \brief Defines the Request class for managing HTTP requests.
+/// \brief Defines the HttpRequest class for configuring HTTP requests.
 
 namespace kurlyk {
 
     /// \class HttpRequest
-    /// \brief Represents an HTTP request.
+    /// \brief Stores HTTP request parameters and settings.
     ///
-    /// The HttpRequest class encapsulates various parameters and settings for an HTTP request,
-    /// including headers, URL, method, data, and connection options. It provides methods
-    /// for configuring these parameters and handling HTTP requests.
+    /// The HttpRequest class stores parameters for an HTTP request,
+    /// including headers, URL, method, body, proxy, TLS, timeout, retry,
+    /// and rate-limit options.
     class HttpRequest {
     public:
         uint64_t request_id = 0;         ///< Unique ID of this concrete HTTP request.
@@ -39,7 +39,7 @@ namespace kurlyk {
         bool follow_location = true;     ///< Automatically follow HTTP redirects.
         long max_redirects   = 10;       ///< Maximum allowed redirects.
         bool auto_referer    = false;    ///< Automatically set Referer header.
-        bool head_only       = false;    ///< If true, sends the request without a response body (HEAD-like behavior).
+        bool head_only       = false;    ///< If true, does not download the response body (HEAD-like behavior).
         bool streaming       = false;    ///< Enable intermediate callbacks for response body chunks.
 
         long timeout         = 30;       ///< Request timeout in seconds.
@@ -58,8 +58,8 @@ namespace kurlyk {
         bool verbose = false;            ///< Enable verbose output (CURLOPT_VERBOSE).
         bool debug_header = false;       ///< Include headers in debug output (CURLOPT_HEADER).
 
-        /// \brief Sets the request URL with host, path, and optional query parameters.
-        /// \param host Hostname or IP address.
+        /// \brief Sets the request URL with base URL, path, and optional query parameters.
+        /// \param host Base URL or host prefix, for example "https://example.com".
         /// \param path Path to resource.
         /// \param query Optional query parameters as a string.
         void set_url(
@@ -77,8 +77,8 @@ namespace kurlyk {
             }
         }
 
-        /// \brief Sets the request URL with host, path, and optional query parameters as a dictionary.
-        /// \param host Hostname or IP address.
+        /// \brief Sets the request URL with base URL, path, and query parameters.
+        /// \param host Base URL or host prefix, for example "https://example.com".
         /// \param path Path to resource.
         /// \param query Query parameters in dictionary format.
         void set_url(
@@ -120,25 +120,25 @@ namespace kurlyk {
         }
 
         /// \brief Sets the Accept-Language header value.
-        /// \param value The language value to be sent with the Accept-Language header.
+        /// \param value Language value to be sent with the Accept-Language header.
         void set_accept_language(const std::string& value) {
             headers.emplace("Accept-Language", value);
         }
 
         /// \brief Sets the Content-Type header value.
-        /// \param value The MIME type for the Content-Type header.
+        /// \param value MIME type for the Content-Type header.
         void set_content_type(const std::string& value) {
             headers.emplace("Content-Type", value);
         }
 
         /// \brief Sets the Origin header value.
-        /// \param value The origin to be sent with the Origin header.
+        /// \param value Origin to be sent with the Origin header.
         void set_origin(const std::string& value) {
             headers.emplace("Origin", value);
         }
 
         /// \brief Sets the Referer header value.
-        /// \param value The referer URL to be sent with the Referer header.
+        /// \param value Referer URL to be sent with the Referer header.
         void set_referer(const std::string& value) {
             headers.emplace("Referer", value);
         }
@@ -217,13 +217,13 @@ namespace kurlyk {
         }
         
         /// \brief Adds a single valid HTTP status code.
-        /// \param status The HTTP status code to add to the set of valid statuses.
+        /// \param status HTTP status code to add to the set of valid statuses.
         void add_valid_status(long status) {
             valid_statuses.insert(status);
         }
 
         /// \brief Sets the valid HTTP status codes, replacing any existing values.
-        /// \param statuses The new set of valid HTTP status codes.
+        /// \param statuses New set of valid HTTP status codes.
         void set_valid_statuses(const std::set<long>& statuses) {
             valid_statuses = statuses;
         }
@@ -289,7 +289,7 @@ namespace kurlyk {
 
     }; // HttpRequest
     
-    /// \brief A unique pointer to an HttpRequest object for memory management.
+    /// \brief Owning pointer to an HTTP request.
     using HttpRequestPtr = std::unique_ptr<HttpRequest>;
 
 }; // namespace kurlyk

--- a/include/kurlyk/http/data/HttpRequest.hpp
+++ b/include/kurlyk/http/data/HttpRequest.hpp
@@ -39,7 +39,7 @@ namespace kurlyk {
         bool follow_location = true;     ///< Automatically follow HTTP redirects.
         long max_redirects   = 10;       ///< Maximum allowed redirects.
         bool auto_referer    = false;    ///< Automatically set Referer header.
-        bool head_only       = false;    ///< If true, does not download the response body (HEAD-like behavior).
+        bool head_only       = false;    ///< If `true`, does not download the response body (HEAD-like behavior).
         bool streaming       = false;    ///< Enable intermediate callbacks for response body chunks.
 
         long timeout         = 30;       ///< Request timeout in seconds.
@@ -270,19 +270,19 @@ namespace kurlyk {
         }
 
         /// \brief Enables or disables intermediate callbacks for response body chunks.
-        /// \param streaming Enable (true) or disable (false) streaming callbacks.
+        /// \param streaming Enable (`true`) or disable (`false`) streaming callbacks.
         void set_streaming(bool streaming) {
             this->streaming = streaming;
         }
 
         /// \brief Enables or disables verbose mode.
-        /// \param verbose Enable (true) or disable (false) verbose output.
+        /// \param verbose Enable (`true`) or disable (`false`) verbose output.
         void set_verbose(bool verbose) {
             this->verbose = verbose;
         }
 
         /// \brief Enables or disables debugging headers in output.
-        /// \param debug_header Enable (true) or disable (false) debug headers.
+        /// \param debug_header Enable (`true`) or disable (`false`) debug headers.
         void set_debug_header(bool debug_header) {
             this->debug_header = debug_header;
         }

--- a/include/kurlyk/http/data/HttpResponse.hpp
+++ b/include/kurlyk/http/data/HttpResponse.hpp
@@ -3,22 +3,22 @@
 #define _KURLYK_HTTP_RESPONSE_HPP_INCLUDED
 
 /// \file HttpResponse.hpp
-/// \brief Defines the HttpResponse class and related types for handling HTTP responses.
+/// \brief Defines the HttpResponse class and related HTTP response types.
 
 namespace kurlyk {
 
     /// \class HttpResponse
-    /// \brief Represents the response received from an HTTP request, including headers, content, and status.
+    /// \brief Represents an HTTP response, including headers, body, status, errors, and timing metrics.
     class HttpResponse {
     public:
         Headers         headers;            ///< HTTP response headers.
-        std::string     content;            ///< The body content of the HTTP response.
-        std::error_code error_code;         ///< Error code indicating issues with the response, if any.
-        std::string     error_message;      ///< Error message detailing the issue, if any.
+        std::string     content;            ///< Body content of the HTTP response.
+        std::error_code error_code;         ///< Error code indicating response or transport issues, if any.
+        std::string     error_message;      ///< Error message describing the issue, if any.
         long            status_code = 0;    ///< HTTP status code of the response (e.g., 200, 404).
         long            retry_attempt = 0;  ///< Number of retry attempts performed for this request.
-        bool            ready = false;      ///< Indicates if the response is final and ready to be processed.
-        bool            stream_chunk = false; ///< Indicates if content contains an intermediate streaming body chunk.
+        bool            ready = false;      ///< Indicates whether the response is final and ready to be processed.
+        bool            stream_chunk = false; ///< Indicates whether content contains an intermediate streaming body chunk.
         
         // --- Timing metrics (all values in seconds) ---
         double namelookup_time    = -1; ///< Time until name resolution completed (DNS).
@@ -29,11 +29,11 @@ namespace kurlyk {
         double total_time         = -1; ///< Total time of the transfer.
     }; // HttpResponse
 
-    /// \brief A unique pointer to an HttpResponse object for memory management.
+    /// \brief Owning pointer to an HTTP response.
     using HttpResponsePtr = std::unique_ptr<HttpResponse>;
 
-    /// \brief Type definition for the callback function used to handle HTTP responses.
-    /// \param response A pointer to the HttpResponse object.
+    /// \brief Callback invoked with an HTTP response.
+    /// \param response Owning pointer to the HTTP response.
     using HttpResponseCallback = std::function<void(HttpResponsePtr response)>;
 
 } // namespace kurlyk

--- a/include/kurlyk/websocket/data/WebSocketConfig.hpp
+++ b/include/kurlyk/websocket/data/WebSocketConfig.hpp
@@ -28,8 +28,8 @@ namespace kurlyk {
         long reconnect_delay    = 5;    ///< Delay in seconds between reconnection attempts.
         long reconnect_attempts = 0;    ///< Number of reconnection attempts (0 means infinite attempts).
         std::size_t max_send_queue_size = 0; ///< Maximum number of queued outbound send operations, or zero if unbounded.
-        bool reconnect      = true;     ///< Enables automatic reconnection if true.
-        bool verify_cert    = true;     ///< If true, verifies the server’s certificate and hostname according to RFC 2818.
+        bool reconnect      = true;     ///< Enables automatic reconnection if `true`.
+        bool verify_cert    = true;     ///< If `true`, verifies the server’s certificate and hostname according to RFC 2818.
 
         /// \struct RateLimitData
         /// \brief Defines rate limit parameters.
@@ -190,7 +190,7 @@ namespace kurlyk {
         }
 
         /// \brief Sets certificate verification and sets the CA certificate file.
-        /// \param verify_cert If true, enables server certificate verification.
+        /// \param verify_cert If `true`, enables server certificate verification.
         /// \param ca_file Path to the CA certificate file.
         void set_ca_file(bool verify_cert, const std::string& ca_file) {
             this->verify_cert = verify_cert;
@@ -198,7 +198,7 @@ namespace kurlyk {
         }
 
         /// \brief Sets whether to verify the server’s certificate.
-        /// \param verify_cert If true, enables server certificate verification.
+        /// \param verify_cert If `true`, enables server certificate verification.
         void set_verify_cert(bool verify_cert) {
             this->verify_cert = verify_cert;
         }

--- a/include/kurlyk/websocket/data/WebSocketConfig.hpp
+++ b/include/kurlyk/websocket/data/WebSocketConfig.hpp
@@ -43,8 +43,8 @@ namespace kurlyk {
 
         std::vector<RateLimitData> rate_limits; ///< List of rate limits applied to WebSocket messages.
 
-        /// \brief Sets the WebSocket server URL with optional query parameters.
-        /// \param host Hostname or IP address.
+        /// \brief Sets the WebSocket server URL with base URL, path, and optional query parameters.
+        /// \param host Base URL or host prefix, for example "wss://example.com".
         /// \param path Path for the request.
         /// \param query Optional query parameters.
         void set_url(const std::string& host, const std::string& path, const std::string& query = "") {
@@ -58,7 +58,7 @@ namespace kurlyk {
             }
         }
 
-        /// \brief Sets the WebSocket server URL with specified query parameters.
+        /// \brief Sets the WebSocket server URL and appends query parameters.
         /// \param url Full URL of the server.
         /// \param query Query parameters as a dictionary.
         void set_url(const std::string& url, const QueryParams& query) {
@@ -209,9 +209,9 @@ namespace kurlyk {
         /// requests by default. Additional rate limits can be added for specific types of requests
         /// or contexts as needed.
         ///
-        /// \param requests_per_period The maximum number of messages allowed within the specified period.
-        /// \param period_ms The time period in milliseconds during which the request limit applies.
-        /// \return The index of the added rate limit configuration.
+        /// \param requests_per_period Maximum number of messages allowed within the specified period.
+        /// \param period_ms Time period in milliseconds during which the request limit applies.
+        /// \return Index of the added rate limit configuration.
         long add_rate_limit(long requests_per_period, long period_ms) {
             rate_limits.emplace_back(requests_per_period, period_ms);
             return rate_limits.size() - 1;
@@ -219,7 +219,7 @@ namespace kurlyk {
 
         /// \brief Adds a rate limit based on Requests Per Minute (RPM).
         /// \param requests_per_minute Maximum number of requests allowed per minute.
-        /// \return The index of the added rate limit configuration.
+        /// \return Index of the added rate limit configuration.
         long add_rate_limit_rpm(long requests_per_minute) {
             long period_ms = 60000; // 1 minute in milliseconds
             return add_rate_limit(requests_per_minute, period_ms);
@@ -227,7 +227,7 @@ namespace kurlyk {
 
         /// \brief Adds a rate limit based on Requests Per Second (RPS).
         /// \param requests_per_second Maximum number of requests allowed per second.
-        /// \return The index of the added rate limit configuration.
+        /// \return Index of the added rate limit configuration.
         long add_rate_limit_rps(long requests_per_second) {
             long period_ms = 1000; // 1 second in milliseconds
             return add_rate_limit(requests_per_second, period_ms);


### PR DESCRIPTION
## Summary

- Clarify `HttpRateLimiter` Doxygen comments around delay semantics, deferred erase behavior, and key cleanup.
- Tighten `HttpRequest` comments to describe it as a request configuration/data object rather than a request handler.
- Clarify URL-building parameters in `HttpRequest` and `WebSocketConfig` as base URL / host prefix.
- Simplify `HttpResponse` pointer and callback descriptions.

## Notes

This PR changes comments only. No runtime logic was modified.