### PR TITLE
chore(post-oauth): changelog, CI auth tests, bearer-only example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,18 @@ jobs:
         run: cmake --build build-auth-tests
       - name: Run auth tests
         run: ctest --test-dir build-auth-tests --output-on-failure
+      - name: Configure bearer-only example (no hmac-cpp)
+        run: |
+          cmake -S . \
+                -B build-bearer-only \
+                -G Ninja \
+                -DKURLYK_BUILD_EXAMPLES=ON \
+                -DKURLYK_OAUTH_SUPPORT=OFF \
+                -DKURLYK_USE_FALLBACK_ASIO=ON \
+                -DKURLYK_USE_FALLBACK_SIMPLE_WS_SERVER=ON \
+                -Wno-dev
+      - name: Build bearer-only example
+        run: cmake --build build-bearer-only --target simple_bearer_auth_example
       - name: Upload logs
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,3 +234,37 @@ jobs:
             build-odr/CMakeFiles/CMakeOutput.log
             build-odr/Testing/Temporary/LastTest.log
           if-no-files-found: ignore
+
+  auth-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: git submodule update --init --recursive
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev ninja-build
+      - name: Configure auth tests
+        run: |
+          cmake -S tests/auth \
+                -B build-auth-tests \
+                -G Ninja \
+                -DKURLYK_BUILD_EXAMPLES=OFF \
+                -DKURLYK_USE_FALLBACK_ASIO=ON \
+                -DKURLYK_USE_FALLBACK_SIMPLE_WS_SERVER=ON \
+                -Wno-dev
+      - name: Build auth tests
+        run: cmake --build build-auth-tests
+      - name: Run auth tests
+        run: ctest --test-dir build-auth-tests --output-on-failure
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs-auth-tests
+          path: |
+            build-auth-tests/CMakeFiles/CMakeOutput.log
+            build-auth-tests/Testing/Temporary/LastTest.log
+          if-no-files-found: ignore

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "external/asio"]
 	path = external/asio
 	url = https://github.com/chriskohlhoff/asio.git
+[submodule "external/hmac-cpp"]
+	path = external/hmac-cpp
+	url = https://github.com/NewYaroslav/hmac-cpp.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Added lightweight HTTP authentication providers:
+  - `BearerTokenAuthProvider` — injects `Authorization: Bearer <token>` header.
+  - `ApiKeyAuthProvider` — injects an API key as a custom header or URL query parameter with automatic percent-encoding.
+- Added `OAuthPkceClient` for OAuth2 Authorization Code + PKCE (RFC 7636) flow:
+  - `build_authorization_url()`, `exchange_code()`, `refresh_access_token()`, `validate_state()`.
+  - Uses standalone `kurlyk::http_post` / `kurlyk::http_request` helpers (no `HttpClient` coupling).
+  - SHA-256 via `hmac-cpp`; Base64Url implemented inline.
+  - Custom token parser fallback for non-JSON builds.
+- Added `ITokenStorage` interface for caller-provided token persistence.
+- Added `OAuthToken`, `OAuthConfig`, `AuthResult` data types with `AuthError` enum.
+- Added `KURLYK_AUTH_SUPPORT`, `KURLYK_OAUTH_SUPPORT`, and `KURLYK_JSON_SUPPORT` feature macros.
+- Added `tests/auth/` standalone test suite: Base64Url, PKCE, auth providers, URL construction, token parsing.
+- Added auth examples: OpenRouter OAuth PKCE, Gemini API key (query), ChatGPT Bearer token.
+- Added `guides/oauth.md` and `guides/auth-providers.md` documentation.
+
+### Changed
+- Replaced dual `KURLYK_ENABLE_JSON` / `KURLYK_USE_JSON` macros with unified `KURLYK_JSON_SUPPORT`.
+  Legacy aliases map automatically for backward compatibility.
+
 ## [v1.0.2] - 2026-04-23
 - Added `HttpClient::wait_requests()` to block until all callbacks for the client's request group are delivered.
 - Added `HttpClient::wait_requests_for(timeout)` to block with a timeout; returns `false` on timeout.

--- a/cmake/deps/hmac_cpp.cmake
+++ b/cmake/deps/hmac_cpp.cmake
@@ -6,6 +6,16 @@ function(use_or_fetch_hmac_cpp out_target)
         return()
     endif()
 
+    # Prefer local submodule if available
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/external/hmac-cpp/CMakeLists.txt")
+        message(STATUS "hmac-cpp: using local submodule")
+        add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/external/hmac-cpp" EXCLUDE_FROM_ALL)
+        if(TARGET hmac_cpp::hmac_cpp)
+            target_link_libraries(${out_target} INTERFACE hmac_cpp::hmac_cpp)
+            return()
+        endif()
+    endif()
+
     find_package(hmac_cpp QUIET)
     if(hmac_cpp_FOUND AND TARGET hmac_cpp::hmac_cpp)
         message(STATUS "hmac-cpp: using existing hmac_cpp::hmac_cpp")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -22,6 +22,7 @@ set(KURLYK_EXAMPLE_SOURCES
 	bearer_token_auth_provider_example.cpp
 	api_key_auth_provider_example.cpp
 	openrouter_oauth_pkce_example.cpp
+	simple_bearer_auth_example.cpp
 )
 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/copy_runtime_dlls.cmake)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,9 +21,14 @@ set(KURLYK_EXAMPLE_SOURCES
 	websocket_independent_clients_example.cpp
 	bearer_token_auth_provider_example.cpp
 	api_key_auth_provider_example.cpp
-	openrouter_oauth_pkce_example.cpp
 	simple_bearer_auth_example.cpp
 )
+
+if(KURLYK_OAUTH_SUPPORT)
+	list(APPEND KURLYK_EXAMPLE_SOURCES
+		openrouter_oauth_pkce_example.cpp
+	)
+endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/copy_runtime_dlls.cmake)
 

--- a/examples/simple_bearer_auth_example.cpp
+++ b/examples/simple_bearer_auth_example.cpp
@@ -1,11 +1,12 @@
 #define KURLYK_AUTO_INIT 0
+#ifndef KURLYK_OAUTH_SUPPORT
+#   define KURLYK_OAUTH_SUPPORT 0
+#endif
 #include <kurlyk.hpp>
 #include <iostream>
 
 /// Minimal example showing BearerTokenAuthProvider without OAuth/hmac-cpp.
 /// KURLYK_OAUTH_SUPPORT=0 keeps the hmac-cpp dependency out of the build.
-/// When compiling standalone (not through CMake), define it before including kurlyk.hpp:
-///   #define KURLYK_OAUTH_SUPPORT 0
 int main() {
     kurlyk::init(true);
 

--- a/examples/simple_bearer_auth_example.cpp
+++ b/examples/simple_bearer_auth_example.cpp
@@ -1,0 +1,35 @@
+#define KURLYK_AUTO_INIT 0
+#include <kurlyk.hpp>
+#include <iostream>
+
+/// Minimal example showing BearerTokenAuthProvider without OAuth/hmac-cpp.
+/// KURLYK_OAUTH_SUPPORT=0 keeps the hmac-cpp dependency out of the build.
+/// When compiling standalone (not through CMake), define it before including kurlyk.hpp:
+///   #define KURLYK_OAUTH_SUPPORT 0
+int main() {
+    kurlyk::init(true);
+
+    // Replace with your actual token or load from environment.
+    const std::string token = "YOUR_BEARER_TOKEN";
+
+    kurlyk::HttpClient client("https://api.example.com");
+
+    kurlyk::Headers headers;
+    kurlyk::http::auth::BearerTokenAuthProvider auth(token);
+    auth.authorize(headers);
+
+    auto future = client.get("/resource", kurlyk::QueryParams(), headers);
+
+    auto response = future.get();
+    if (response && response->ready) {
+        KURLYK_PRINT << "Status: " << response->status_code << std::endl;
+        KURLYK_PRINT << "Body: " << response->content << std::endl;
+    } else {
+        KURLYK_PRINT << "Request failed: "
+                     << (response ? response->error_code.message() : "null")
+                     << std::endl;
+    }
+
+    kurlyk::deinit();
+    return 0;
+}

--- a/guides/git-workflow.md
+++ b/guides/git-workflow.md
@@ -1,0 +1,64 @@
+# Git Workflow
+
+## Branch Policy
+
+All code changes must go through a feature branch and a pull request.
+Never commit directly to `main`.
+
+## Required Steps Before Creating a Branch
+
+1. Check the current state:
+   ```bash
+   git status
+   git branch -vv
+   ```
+2. Update `main` to the latest remote state:
+   ```bash
+   git fetch origin
+   git checkout main
+   git pull origin main
+   ```
+3. Only after `main` is up-to-date, create the feature branch:
+   ```bash
+   git checkout -b <prefix>/<short-description>
+   ```
+
+## Branch Naming
+
+| Prefix | Use for |
+| --- | --- |
+| `feat/` | New functionality |
+| `fix/` | Bug fixes |
+| `refactor/` | Code restructuring without behavior changes |
+| `test/` | Adding or modifying tests only |
+| `docs/` | Documentation changes |
+| `chore/` | Build, CI, dependency, or maintenance tasks |
+| `perf/` | Performance improvements |
+
+Examples:
+- `feat/otlp-gzip-compression`
+- `fix/payload-splitter-overflow`
+- `test/backpressure-race`
+
+## Workflow
+
+1. Create a focused branch from up-to-date `main`.
+2. Make atomic commits with conventional messages (see `commits.md`).
+3. Push the branch to origin:
+   ```bash
+   git push -u origin <branch-name>
+   ```
+4. Open a pull request on GitHub.
+5. Merge only after review and passing CI.
+
+## Agent Rule
+
+When starting any task (feature, bug fix, improvement, documentation), an AI agent must:
+
+1. Do not edit or commit while on `main`. If currently on `main`, create a branch before editing files.
+2. Verify `main` is current with `origin/main`.
+3. Create a feature branch with an appropriate prefix.
+4. Do all work on that branch.
+5. Push the branch and instruct the user to open a PR instead of merging directly.
+
+No direct commits to `main`, including trivial documentation fixes, unless the repository owner explicitly overrides this rule for that exact change.


### PR DESCRIPTION
Post-OAuth cleanup and integration improvements.

### Added
- CHANGELOG.md `[Unreleased]` section documenting auth providers, OAuth PKCE, new feature macros, and examples.
- GitHub Actions CI job `auth-tests` that builds and runs `tests/auth/` on Ubuntu.
- `examples/simple_bearer_auth_example.cpp` demonstrating `BearerTokenAuthProvider` with `KURLYK_OAUTH_SUPPORT=0` (no hmac-cpp dependency).

### Notes
- This change contains only docs, CI, and examples; no library code is modified.