### PR TITLE
Post OAuth cleanup

### DIFF
--- a/guides/critical-defaults.md
+++ b/guides/critical-defaults.md
@@ -28,4 +28,5 @@ Mandatory rules for every repository task.
 
 ## Git
 
+All changes reach `main` through PRs; do not push directly to `main` unless the user explicitly overrides this rule.
 See [Git workflow](git-workflow.md) for the full branch and PR policy.

--- a/tests/integration/http_client_auth_provider_main.cpp
+++ b/tests/integration/http_client_auth_provider_main.cpp
@@ -76,7 +76,24 @@ int main() {
     {
         ProcessorGuard pg;
 
-        // --- Test 1: BearerTokenAuthProvider injected via HttpClient ---
+        // --- Test 1: auth provider accessors reflect client state ---
+        {
+            auto client = std::make_unique<kurlyk::HttpClient>(base_url);
+            require(!client->has_auth_provider(), "client must start without auth provider");
+            require(client->auth_provider() == nullptr, "auth_provider() must return nullptr initially");
+
+            auto provider = std::make_shared<kurlyk::http::auth::BearerTokenAuthProvider>(
+                "accessor-token");
+            client->set_auth_provider(provider);
+            require(client->has_auth_provider(), "has_auth_provider() must be true after set_auth_provider()");
+            require(client->auth_provider() == provider, "auth_provider() must return assigned provider");
+
+            client->clear_auth_provider();
+            require(!client->has_auth_provider(), "has_auth_provider() must be false after clear_auth_provider()");
+            require(client->auth_provider() == nullptr, "auth_provider() must return nullptr after clear_auth_provider()");
+        }
+
+        // --- Test 2: BearerTokenAuthProvider injected via HttpClient ---
         {
             last_auth_header.clear();
             auto client = std::make_unique<kurlyk::HttpClient>(base_url);
@@ -95,7 +112,7 @@ int main() {
                     "Authorization header must be injected by BearerTokenAuthProvider");
         }
 
-        // --- Test 2: per-request Authorization header overwritten by provider ---
+        // --- Test 3: per-request Authorization header overwritten by provider ---
         {
             last_auth_header.clear();
             auto client = std::make_unique<kurlyk::HttpClient>(base_url);
@@ -116,7 +133,7 @@ int main() {
                     "provider must overwrite per-request Authorization header");
         }
 
-        // --- Test 3: set_auth_provider(nullptr) disables injection ---
+        // --- Test 4: set_auth_provider(nullptr) disables injection ---
         {
             last_auth_header.clear();
             auto client = std::make_unique<kurlyk::HttpClient>(base_url);


### PR DESCRIPTION
## Summary

- Add `HttpClient` auth provider accessors for reading, checking, and clearing the configured provider.
- Prevent `cancel_requests()` from deadlocking on an idle request group.
- Add integration coverage for auth provider accessors and idle `wait_requests()` behavior.
- Restore explicit PR-only Git policy text in critical defaults while keeping the detailed workflow link.

## Validation

- `cmake --build tests/integration/build4 --target http_client_auth_provider_test --config Release`
- `ctest --test-dir tests/integration/build4 -R http_client_auth_provider_test --output-on-failure`